### PR TITLE
Prevent "None" from appearing in identification output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,13 +57,19 @@ runs:
             if ext_suffix is not None:
                 print(ext_suffix, end="")
             else:
-                # Python 2.7 on GitHub macOS runners
+                # Python 2.7 is still pre-installed on GitHub macOS runners.
                 import platform
 
+                implementation = platform.python_implementation().lower()
+                implementation_version = "".join(platform.python_version_tuple()[:2])
+                platform_system = platform.system().lower()
+                platform_machine = platform.machine().lower()
+
                 print(
-                    "." + platform.python_implementation().lower(),
-                    sysconfig.get_config_var("py_version_nodot"),
-                    sysconfig.get_config_var("MACHDEP"),
+                    "." + implementation,
+                    implementation_version,
+                    platform_system,
+                    platform_machine,
                     sep="-",
                     end="",
                 )

--- a/changelog.d/20231031_064619_kurtmckee_resolve_none_in_identifications.rst
+++ b/changelog.d/20231031_064619_kurtmckee_resolve_none_in_identifications.rst
@@ -1,0 +1,5 @@
+Changed
+-------
+
+*   ``None`` should no longer appear in the identifier
+    for Python interpreters missing an ``EXT_SUFFIX`` sysconfig value.

--- a/src/detect_pythons/detector.sh
+++ b/src/detect_pythons/detector.sh
@@ -17,13 +17,19 @@ def main():
     if ext_suffix is not None:
         print(ext_suffix, end="")
     else:
-        # Python 2.7 on GitHub macOS runners
+        # Python 2.7 is still pre-installed on GitHub macOS runners.
         import platform
 
+        implementation = platform.python_implementation().lower()
+        implementation_version = "".join(platform.python_version_tuple()[:2])
+        platform_system = platform.system().lower()
+        platform_machine = platform.machine().lower()
+
         print(
-            "." + platform.python_implementation().lower(),
-            sysconfig.get_config_var("py_version_nodot"),
-            sysconfig.get_config_var("MACHDEP"),
+            "." + implementation,
+            implementation_version,
+            platform_system,
+            platform_machine,
             sep="-",
             end="",
         )

--- a/src/detect_pythons/identify.py
+++ b/src/detect_pythons/identify.py
@@ -13,13 +13,19 @@ def main():
     if ext_suffix is not None:
         print(ext_suffix, end="")
     else:
-        # Python 2.7 on GitHub macOS runners
+        # Python 2.7 is still pre-installed on GitHub macOS runners.
         import platform
 
+        implementation = platform.python_implementation().lower()
+        implementation_version = "".join(platform.python_version_tuple()[:2])
+        platform_system = platform.system().lower()
+        platform_machine = platform.machine().lower()
+
         print(
-            "." + platform.python_implementation().lower(),
-            sysconfig.get_config_var("py_version_nodot"),
-            sysconfig.get_config_var("MACHDEP"),
+            "." + implementation,
+            implementation_version,
+            platform_system,
+            platform_machine,
             sep="-",
             end="",
         )

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -29,3 +29,5 @@ def test_main_ext_suffix_fallback(capsys, monkeypatch):
     assert implementation in stdout
     assert version in stdout
     assert stdout == stdout.strip()
+
+    assert "none" not in stdout.lower()


### PR DESCRIPTION
Changed
-------

*   ``None`` should no longer appear in the identifier
    for Python interpreters missing an ``EXT_SUFFIX`` sysconfig value.
