### PR TITLE
Enforce LF newlines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,13 @@ repos:
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
     rev: "v4.5.0"
     hooks:
-      - id: "trailing-whitespace"
-      - id: "end-of-file-fixer"
       - id: "check-yaml"
       - id: "check-added-large-files"
+      - id: "end-of-file-fixer"
+      - id: "mixed-line-ending"
+        args:
+          - "--fix=lf"
+      - id: "trailing-whitespace"
 
   - repo: "https://github.com/psf/black-pre-commit-mirror"
     rev: "23.10.1"


### PR DESCRIPTION
On Windows, scriv outputs CRLF files and the EditorConfig checker complains.

This introduces a pre-commit hook to rewrite newlines to LF.