### PR TITLE
Remove the redundant tox `skip_missing_interpreters` setting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,9 @@
 [tox]
 min_version = 4.3.5
-
 envlist =
     coverage_erase
     py{3.13, 3.12, 3.11, 3.10, 3.9, 3.8, py3.10, py3.9, py3.8}
     coverage_report
-
-skip_missing_interpreters = True
 labels =
     update=update
 


### PR DESCRIPTION

This PR removes the redundant tox `skip_missing_interpreters` setting in `tox.ini`.
This codifies the recently-discovered fact that it's true by default.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>